### PR TITLE
Configure Tailwind class-based dark mode matching data-theme selector

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: ['selector', '[data-theme="dark"]'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Closes #18. Configured darkMode selector mapping in tailwind.config.js to synchronize all Tailwind dark mode classes with the local theme toggle state instead of the device preferences.