### PR TITLE
Fix: Handle 403 error gracefully for restaurant promotions

### DIFF
--- a/src/pages/RestaurantDetails.tsx
+++ b/src/pages/RestaurantDetails.tsx
@@ -253,12 +253,22 @@ const RestaurantDetails = () => {
             if (!isMockId) {
               try {
                 setReviewsLoading(true);
-                const [reviewsData, promosData] = await Promise.all([
-                  businessApi.getReviews(id),
-                  businessApi.getPromotions(id)
-                ]);
+                
+                // Fetch reviews
+                const reviewsData = await businessApi.getReviews(id);
                 setReviews(Array.isArray(reviewsData) ? reviewsData : []);
-                setPromotions(Array.isArray(promosData) ? promosData.filter((p: any) => p.status === 'active' || p.isActive) : []);
+                
+                // Try to fetch promotions, but don't fail if user doesn't have access
+                try {
+                  const promosData = await businessApi.getPromotions(id);
+                  setPromotions(Array.isArray(promosData) ? promosData.filter((p: any) => p.status === 'active' || p.isActive) : []);
+                } catch (promoErr: any) {
+                  // Silently handle 403 (regular users can't see promotions)
+                  if (promoErr?.response?.status !== 403) {
+                    console.error('Failed to fetch promotions:', promoErr);
+                  }
+                  setPromotions([]);
+                }
               } catch (err) {
                 console.error('Failed to fetch storefront data:', err);
                 setReviews([]);


### PR DESCRIPTION
## Changes
This PR fixes the 403 Forbidden error that regular users encounter when viewing restaurant details pages.

## Problem
- Regular users got 403 errors when loading restaurant details
- The `/api/v1/business/:id/promotions` endpoint requires business owner role
- Error broke the user experience on restaurant detail pages

## Solution
✅ Separated promotions API call from reviews fetch (no longer using `Promise.all()`)
✅ Added nested try-catch to handle 403 errors gracefully
✅ Promotions silently set to empty array when access denied
✅ Reviews continue to load independently
✅ Graceful degradation - promotions section won't display for regular users

## Technical Details
**File Modified:** `src/pages/RestaurantDetails.tsx`

**Before:**
```typescript
const [reviewsData, promosData] = await Promise.all([
  businessApi.getReviews(id),
  businessApi.getPromotions(id)
]);
```

**After:**
```typescript
const reviewsData = await businessApi.getReviews(id);
try {
  const promosData = await businessApi.getPromotions(id);
  setPromotions(/* ... */);
} catch (promoErr) {
  if (promoErr?.response?.status !== 403) {
    console.error('Failed to fetch promotions:', promoErr);
  }
  setPromotions([]);
}
```

## Testing
- ✅ Regular users can view restaurant details without errors
- ✅ Reviews load correctly
- ✅ Promotions section doesn't appear for regular users (expected behavior)
- ✅ Backend access control remains enforced
- ✅ No breaking changes

## Related Issue
Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restaurant details now continue loading reviews even when promotions cannot be retrieved.
  * Authorization-related promotion errors no longer interrupt the storefront experience.
  * Promotion content gracefully falls back to an empty state when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->