### PR TITLE
build: add render.yaml with bun build configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: dineingo-backend
+    env: node
+    rootDir: backend
+    buildCommand: bun run build
+    startCommand: bun start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: NODE_OPTIONS
+        value: --max-old-space-size=1024


### PR DESCRIPTION
- Configure Render deployment to use bun for building and starting backend
- Specify buildCommand: 'bun run build' to compile TypeScript
- Set startCommand: 'bun start' to run the compiled server
- Add NODE_ENV=production for optimal performance
- Fixes: MODULE_NOT_FOUND error on Render deployment